### PR TITLE
Use $HOME instead of ~ so sshkit 1.8.0 works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# master (unreleased)
+
+* Change default `nodenv_path` to use `$HOME` instead of `~`. This allows
+  capistrano-nodenv to work with the new quoting behavior of sshkit 1.8.0.
+
 # 1.0.0
 
 * Added ability to setup custom `nodenv_roles` variable (default: :all).

--- a/lib/capistrano/tasks/nodenv.rake
+++ b/lib/capistrano/tasks/nodenv.rake
@@ -37,7 +37,7 @@ namespace :load do
       nodenv_path ||= if fetch(:nodenv_type, :user) == :system
         "/usr/local/nodenv"
       else
-        "~/.nodenv"
+        "$HOME/.nodenv"
       end
     }
 


### PR DESCRIPTION
Fixes https://github.com/platanus/capistrano-nodenv/issues/3
